### PR TITLE
Fix Dataiku tools and revert registry

### DIFF
--- a/coded_tools/dataiku/__init__.py
+++ b/coded_tools/dataiku/__init__.py
@@ -1,0 +1,1 @@
+# Package for Dataiku tools

--- a/coded_tools/dataiku/approvals_required_tool.py
+++ b/coded_tools/dataiku/approvals_required_tool.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from typing import Any, Dict
+
+from neuro_san.interfaces.coded_tool import CodedTool
+
+
+class ApprovalsRequiredTool(CodedTool):
+    """Check if access is permitted based on policies."""
+
+    def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> bool:
+        env = str(args.get("env", "")).upper()
+        access_type = str(args.get("access_type", "")).capitalize()
+
+        file_path = Path(__file__).parent / "knowdocs" / "access_policies.md"
+        try:
+            lines = [line.strip() for line in file_path.read_text(encoding="utf-8").splitlines()]
+            rows = [ln for ln in lines if "|" in ln][2:]
+            for row in rows:
+                parts = [p.strip() for p in row.strip("|").split("|")]
+                if len(parts) < 3:
+                    continue
+                if parts[0].upper() == env and parts[1].capitalize() == access_type:
+                    return parts[2].lower() == "yes"
+            return False
+        except Exception:  # pragma: no cover - simple demo
+            return False

--- a/coded_tools/dataiku/knowdocs/access_policies.md
+++ b/coded_tools/dataiku/knowdocs/access_policies.md
@@ -1,0 +1,11 @@
+## Access Policies
+| Environment | Access Type | Allowed |
+|-------------|-------------|---------|
+| DEV         | Read        | yes     |
+| DEV         | Write       | yes     |
+| QA          | Read        | yes     |
+| QA          | Write       | no      |
+| PROD        | Read        | yes     |
+| PROD        | Write       | no      |
+| CORE++      | Read        | yes     |
+| CORE++      | Write       | no      |

--- a/coded_tools/dataiku/knowdocs/training_completions.md
+++ b/coded_tools/dataiku/knowdocs/training_completions.md
@@ -1,0 +1,4 @@
+## Training Completions
+| User ID | Name         | Training_type     | Certificate_Id | Completion_date |
+|---------|--------------|-------------------|----------------|-----------------|
+| 100     | Gordon Banks | DEV_training      | 2111           | 01.01.2025      |

--- a/coded_tools/dataiku/knowdocs/training_requirements.md
+++ b/coded_tools/dataiku/knowdocs/training_requirements.md
@@ -1,0 +1,19 @@
+## Training Required
+{
+    "DEV": {
+        "training_name": "DEV_training",
+        "training_url": "https://www.training_platform/train_dev.com"
+    },
+    "QA": {
+        "training_name": "QA_training",
+        "training_url": "https://www.training_platform/train_qa.com"
+    },
+    "PROD": {
+        "training_name": "PROD_training",
+        "training_url": "https://www.training_platform/train_prod.com"
+    },
+    "CORE++": {
+        "training_name": "CORE++_training",
+        "training_url": "https://www.training_platform/train_core++.com"
+    }
+}

--- a/coded_tools/dataiku/knowdocs/users.md
+++ b/coded_tools/dataiku/knowdocs/users.md
@@ -1,0 +1,4 @@
+## Users
+| User ID | Name         | DataIku ID | Location | Status | D1 | D2 | D3 |
+|---------|--------------|------------|----------|--------|----|----|----|
+| 100     | Gordon Banks | 300        | England  | A      | R  | R  | R  |

--- a/coded_tools/dataiku/ons_ticket_creator_tool.py
+++ b/coded_tools/dataiku/ons_ticket_creator_tool.py
@@ -1,0 +1,11 @@
+import uuid
+from typing import Any, Dict
+
+from neuro_san.interfaces.coded_tool import CodedTool
+
+
+class ONSTicketCreatorTool(CodedTool):
+    """Generate a mock ServiceNow ticket number."""
+
+    def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
+        return f"SNOW-{uuid.uuid4().hex[:8]}"

--- a/coded_tools/dataiku/ons_ticket_verification_tool.py
+++ b/coded_tools/dataiku/ons_ticket_verification_tool.py
@@ -1,0 +1,11 @@
+from typing import Any, Dict
+
+from neuro_san.interfaces.coded_tool import CodedTool
+
+
+class ONSTicketVerificationTool(CodedTool):
+    """Simple validator for ServiceNow ticket numbers."""
+
+    def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> bool:
+        ticket_number = args.get("ticket_number", "")
+        return bool(ticket_number) and str(ticket_number).startswith("SNOW-")

--- a/coded_tools/dataiku/training_completions_tool.py
+++ b/coded_tools/dataiku/training_completions_tool.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from typing import Any, Dict
+
+from neuro_san.interfaces.coded_tool import CodedTool
+
+
+class TrainingCompletionsTool(CodedTool):
+    """Check if a user completed a training."""
+
+    def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> bool:
+        user_id = str(args.get("user_id", ""))
+        training_name = args.get("training_name", "")
+        certificate_id = args.get("certificate_id", "")
+
+        file_path = Path(__file__).parent / "knowdocs" / "training_completions.md"
+        try:
+            lines = [line.strip() for line in file_path.read_text(encoding="utf-8").splitlines()]
+            rows = [ln for ln in lines if "|" in ln][2:]
+            for row in rows:
+                parts = [p.strip() for p in row.strip("|").split("|")]
+                if len(parts) < 5:
+                    continue
+                if parts[0] == user_id and parts[2] == training_name and parts[3] == certificate_id:
+                    return True
+            return False
+        except Exception:  # pragma: no cover - simple demo
+            return False

--- a/coded_tools/dataiku/training_requirements_tool.py
+++ b/coded_tools/dataiku/training_requirements_tool.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from neuro_san.interfaces.coded_tool import CodedTool
+
+
+class TrainingRequirementsTool(CodedTool):
+    """Return training requirements for a specific environment."""
+
+    def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Dict[str, Any]:
+        env = str(args.get("env", "")).upper()
+        file_path = Path(__file__).parent / "knowdocs" / "training_requirements.md"
+        try:
+            text = file_path.read_text(encoding="utf-8")
+            json_start = text.find("{")
+            json_end = text.rfind("}") + 1
+            data = json.loads(text[json_start:json_end])
+            return data.get(env, {})
+        except Exception:  # pragma: no cover - simple demo
+            return {}

--- a/coded_tools/dataiku/user_verification_tool.py
+++ b/coded_tools/dataiku/user_verification_tool.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from typing import Any, Dict
+
+from neuro_san.interfaces.coded_tool import CodedTool
+
+
+class UserVerificationTool(CodedTool):
+    """Verify a user's identity from the users table."""
+
+    def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> bool:
+        user_id = str(args.get("user_id", ""))
+        dataiku_id = str(args.get("dataiku_id", ""))
+
+        file_path = Path(__file__).parent / "knowdocs" / "users.md"
+        try:
+            lines = [line.strip() for line in file_path.read_text(encoding="utf-8").splitlines()]
+            rows = [ln for ln in lines if "|" in ln][2:]
+            for row in rows:
+                parts = [p.strip() for p in row.strip("|").split("|")]
+                if len(parts) < 3:
+                    continue
+                if parts[0] == user_id and parts[2] == dataiku_id and parts[4] == "A":
+                    return True
+            return False
+        except Exception:  # pragma: no cover - simple demo
+            return False


### PR DESCRIPTION
## Summary
- revert `dataiku.hocon` to its original version
- refine Dataiku helper tools and clean up type hints

## Testing
- `isort coded_tools/dataiku/approvals_required_tool.py coded_tools/dataiku/training_requirements_tool.py coded_tools/dataiku/training_completions_tool.py coded_tools/dataiku/user_verification_tool.py coded_tools/dataiku/ons_ticket_verification_tool.py coded_tools/dataiku/ons_ticket_creator_tool.py`
- `black coded_tools/dataiku/approvals_required_tool.py coded_tools/dataiku/training_requirements_tool.py coded_tools/dataiku/training_completions_tool.py coded_tools/dataiku/user_verification_tool.py coded_tools/dataiku/ons_ticket_verification_tool.py coded_tools/dataiku/ons_ticket_creator_tool.py`
- `flake8` *(fails: command not found)*
- `pylint coded_tools/dataiku/approvals_required_tool.py` *(fails: command not found)*
- `pytest -q` *(fails due to unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685501ac6b048331bd5975b3337a8320